### PR TITLE
fixed Next.js link in S3 plugin documentation

### DIFF
--- a/docs/content/add-plugins/s3.md
+++ b/docs/content/add-plugins/s3.md
@@ -150,7 +150,7 @@ You can also check that the image was uploaded on the S3 bucket’s page.
 
 ## Next.js Storefront Configuration
 
-If you’re using a [Next.js](../starters/nextjs-medusa-starter.md storefront, you need to add an additional configuration that adds the S3 bucket domain name into the configured images’ domain names. This is because all URLs of product images will be from the S3 bucket.
+If you’re using a [Next.js](../starters/nextjs-medusa-starter.md) storefront, you need to add an additional configuration that adds the S3 bucket domain name into the configured images’ domain names. This is because all URLs of product images will be from the S3 bucket.
 
 If this configuration is not added, you’ll receive the error ["next/image Un-configured Host”](https://nextjs.org/docs/messages/next-image-unconfigured-host).
 


### PR DESCRIPTION
fixes [this](https://github.com/medusajs/medusa/issues/1977) docs issue

**what**

- fixed the nextJs link in s3 plugin documentation using markdown link 

**how**

- just corrected the documentations markdown path in docs/content/add-plugins/s3.md
